### PR TITLE
Bump `golangci-lint` to `v1.44.0` in `README.md` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ jobs:
         uses: flipgroup/action-golang-with-lint@main
         with:
           version-golang: ~1.17
-          version-golangci-lint: v1.43.0
+          version-golangci-lint: v1.44.0
 ```


### PR DESCRIPTION
Just for the sake of keeping things inline to the parent `golangci-lint` project and it's latest release.