### PR TITLE
Bump to `v1.44.2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ jobs:
         uses: flipgroup/action-golang-with-lint@main
         with:
           version-golang: ~1.17
-          version-golangci-lint: v1.44.0
+          version-golangci-lint: v1.44.2
 ```


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.44.2