### PR TITLE
Bump GitHub actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub Action for setting up Golang via [actions/setup-go](https://github.com/ac
 
 At completion of Action, runner will be left with the desired Golang version, ready for running additional quality of life operations - such as `go test`.
 
-**Note:** internally, the [golangci/golangci-lint-action](https://github.com/golangci/golangci-lint-action) action provides caching of the Golang build/module cache directories - so no requirement to handle this within the composite action.
+**Note:** internally, [golangci/golangci-lint-action](https://github.com/golangci/golangci-lint-action) provides caching of the Golang build/module cache directories - so no requirement to handle this within the composite action.
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,6 @@ runs:
       with:
         go-version: ${{ inputs.version-golang }}
     - name: Lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
-        skip-go-installation: true
         version: ${{ inputs.version-golangci-lint }}

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Setup Golang
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.version-golang }}
     - name: Lint


### PR DESCRIPTION
- https://github.com/actions/setup-go/releases/tag/v3.0.0
- Bumped `golangci/golangci-lint-action@v3`
  - Nice to see, `setup-go` is no longer used internally - so able to drop the `skip-go-installation: true` argument.
  - See: https://github.com/golangci/golangci-lint-action/pull/403