### PR TITLE
Add `go-version-file` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub Action for setting up Golang via [actions/setup-go](https://github.com/ac
 
 At completion of Action, runner will be left with the desired Golang version, ready for running additional quality of life operations - such as `go test`.
 
-**Note:** internally, [golangci/golangci-lint-action](https://github.com/golangci/golangci-lint-action) provides caching of the Golang build/module cache directories - so no requirement to handle this within the composite action.
+**Note:** internally, [golangci/golangci-lint-action](https://github.com/golangci/golangci-lint-action) provides caching of the Golang build and module cache directories - so no requirement to handle this from within the composite action itself.
 
 ## Usage
 
@@ -17,6 +17,8 @@ jobs:
       - name: Setup Golang with lint
         uses: flipgroup/action-golang-with-lint@main
         with:
-          version-golang: ~1.17
-          version-golangci-lint: v1.44.2
+          version-golang-file: go.mod
+          # alternatively, use `version-golang` input
+          #version-golang: ~1.18
+          version-golangci-lint: v1.47.0
 ```

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,8 @@ name: Golang with golangci-lint linting
 inputs:
   version-golang:
     description: Golang version.
-    required: true
+  version-golang-file:
+    description: Golang version from go.mod. Used in place of `version-golang`.
   version-golangci-lint:
     description: golangci-lint version.
     required: true
@@ -15,6 +16,7 @@ runs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.version-golang }}
+        go-version-file: ${{ inputs.version-golang-file }}
     - name: Lint
       uses: golangci/golangci-lint-action@v3
       with:


### PR DESCRIPTION
The https://github.com/actions/setup-go now conveniently supports setting the Golang version by reading a `go.mod` file.

This _should_ mean a project should only have to set the target Golang version once within a project. Win win 🎉 

Adding new `version-golang-file` input to pass this filespec through. Input `version-golang` is still safely supported - but obviously only one input should be passed to set version.

Related: https://github.com/flipgroup/action-golang-with-cache/pull/3