### PR TITLE
Bump `actions/setup-go@v4`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ jobs:
           version-golang-file: go.mod
           # alternatively, use `version-golang` input
           #version-golang: ~1.18
-          version-golangci-lint: v1.47.0
+          version-golangci-lint: v1.52.0
 ```

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,9 @@ runs:
   using: composite
   steps:
     - name: Setup Golang
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
+        cache: false
         go-version: ${{ inputs.version-golang }}
         go-version-file: ${{ inputs.version-golang-file }}
     - name: Lint


### PR DESCRIPTION
Bump [actions/setup-go@v4](https://github.com/actions/setup-go/releases/tag/v4.0.0) (not using internal caching).