### PR TITLE
Add explicit `default:` property to `version-golang` / `version-golang-file` inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,10 @@ name: Golang with golangci-lint linting
 inputs:
   version-golang:
     description: Golang version.
+    default:
   version-golang-file:
     description: Golang version from go.mod. Used in place of `version-golang`.
+    default:
   version-golangci-lint:
     description: golangci-lint version.
     required: true


### PR DESCRIPTION
As per the title, just adding explicit empty `default:` for `version-golang` / `version-golang-file` inputs.