### PR TITLE
GitHub actions bump

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,12 +15,12 @@ runs:
   using: composite
   steps:
     - name: Setup Golang
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         cache: false
         go-version: ${{ inputs.version-golang }}
         go-version-file: ${{ inputs.version-golang-file }}
     - name: Lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v4
       with:
         version: ${{ inputs.version-golangci-lint }}


### PR DESCRIPTION
Bumping GitHub Action versions to those supporting Node.js v20 - [since v16 is now deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).