### PR TITLE
Bump `golangci/golangci-lint-action@v8` for v2 support of `golangci-lint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ jobs:
           version-golang-file: go.mod
           # alternatively, use `version-golang` input
           #version-golang: ~1.24
-          version-golangci-lint: v1.64.6
+          version-golangci-lint: v2.1.6
 ```

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,6 @@ runs:
         version: ${{ inputs.version-golang }}
         version-file: ${{ inputs.version-golang-file }}
     - name: Lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
         version: ${{ inputs.version-golangci-lint }}


### PR DESCRIPTION
Update to https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0 for v2 support of `golangci-lint`.
