### PR TITLE
Update `golangci/golangci-lint-action@v9`, bump linter version in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ jobs:
         with:
           version-golang-file: go.mod
           # alternatively, use `version-golang` input
-          #version-golang: ~1.24
-          version-golangci-lint: v2.2.1
+          #version-golang: ~1.26
+          version-golangci-lint: v2.11.4
 ```

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,6 @@ runs:
         version: ${{ inputs.version-golang }}
         version-file: ${{ inputs.version-golang-file }}
     - name: Lint
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@v9
       with:
         version: ${{ inputs.version-golangci-lint }}


### PR DESCRIPTION
- Update `golangci-lint-action@v9`.
- Updates to `README.md` with latest release bumps.
