### PR TITLE
GitHub Actions bump Node.js `v24` releases

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Flip Group
+Copyright (c) 2026 Flip Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,6 @@ runs:
         version: ${{ inputs.version-golang }}
         version-file: ${{ inputs.version-golang-file }}
     - name: Lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # @v9.2.1
       with:
         version: ${{ inputs.version-golangci-lint }}


### PR DESCRIPTION
Applies the following GitHub Action workflow changes:

- Swap out the use of version tags for external actions to full SHA-1 commits to defeat action tainting / supply chain attacks.
